### PR TITLE
Add assemble-sdks CI job and add Termux packages necessary for XML and networking

### DIFF
--- a/.github/workflows/sdks.yml
+++ b/.github/workflows/sdks.yml
@@ -225,11 +225,6 @@ jobs:
 
             NDK_PREBUILT=${ANDROID_NDK_LATEST_HOME}/toolchains/llvm/prebuilt/darwin-x86_64
 
-            # With the full SDK, the libs are all located in:
-            #"-L", "${SDK}/usr/lib/${ARCHID}"
-            # But with the partial SDK, they are divided between:
-            #"-L", "${SDK_PATH}/usr/lib",
-            #"-L", "${SDK_PATH}/usr/lib/swift/android",
             cat > ${ARCH_JSON} << EOF
             {
                 "version": 1,
@@ -480,3 +475,82 @@ jobs:
           api-level: 29
           arch: x86_64
           script: ~/test-toolchain.sh
+      - name: Get cached SDK (aarch64)
+        if: ${{ matrix.os == 'ubuntu-22.04' && matrix.arch == 'x86_64' }}
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/swift-${{ matrix.version }}-android-aarch64-*-sdk.tar.xz
+          key: ${{ steps.version.outputs.tag }}-aarch64-ndk-27b-sdk
+          fail-on-cache-miss: true
+      - name: Get cached SDK (armv7)
+        if: ${{ matrix.os == 'ubuntu-22.04' && matrix.arch == 'x86_64' }}
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/swift-${{ matrix.version }}-android-armv7-*-sdk.tar.xz
+          key: ${{ steps.version.outputs.tag }}-armv7-ndk-27b-sdk
+          fail-on-cache-miss: true
+      - name: Assemble SDK
+        if: ${{ matrix.os == 'ubuntu-22.04' && matrix.arch == 'x86_64' }}
+        id: assemble-sdk
+        run: |
+          set -x
+          ls -lah ~/swift-*-sdk.tar.xz
+
+          # e.g. swift-5.10.1-RELEASE-android-sdk
+          SDK_DIR=${{ steps.version.outputs.tag }}-android-${ANDROID_API_LEVEL}-sdk
+          echo "SDK_DIR=${SDK_DIR}" >> $GITHUB_ENV
+          mkdir ${SDK_DIR}
+
+          for SDK_PATH in ~/swift-*-sdk.tar.xz; do
+            MERGEDIR=$(basename $SDK_PATH .tar.xz)
+            mkdir ${MERGEDIR}
+            pushd ${MERGEDIR}
+            # e.g. swift-android-sdk-release-aarch64/swift-release-android-aarch64-24-sdk.tar.xz
+            tar xf ${SDK_PATH}
+            tree swift-*-sdk
+            pushd swift-*-sdk
+
+            ARCH=$(ls usr/lib/swift_static/android/*/swiftrt.o | cut -f 5 -d '/')
+
+            TRIPLE="${ARCH}-linux-android"
+            if [[ $ARCH == 'armv7' ]]; then
+                TRIPLE="arm-linux-androideabi"
+            fi
+
+            echo "Creating ${TRIPLE} from ${MERGEDIR}…"
+
+            mkdir -p usr/lib/${TRIPLE}
+            rm -r usr/bin
+            mv usr/lib/swift_static/android/*.a usr/lib/swift_static/android/${ARCH}/
+            patchelf --set-rpath \$ORIGIN usr/lib/swift/android/lib[FXs]*.so
+            mv usr/lib/*.so* usr/lib/swift/android/*.so* usr/lib/${TRIPLE}
+            mv usr/lib/pkgconfig usr/lib/${TRIPLE}
+            rm -r usr/lib/swift/pm
+            # clear the symlink to /home/runner/work/swift-android-sdk/swift-android-sdk/sdk-config/swift-5.10.1-RELEASE-ubuntu22.04/usr/lib/clang/15.0.0
+            # we will reference it with an -I flag in the destination.json instead
+            rm usr/lib/swift_static/clang
+            rm usr/lib/swift/clang
+
+            popd
+            popd
+
+            # copy all the processed SDK files into the SDK_DIR
+            rsync -ar ${MERGEDIR}/swift-*-sdk/ "${SDK_DIR}"
+          done
+
+          # output visualization of the SDK_DIR file tree
+          tree "${SDK_DIR}"
+
+          echo "Merged toolchains into ${SDK_DIR}"
+          du -skh "${SDK_DIR}"
+          tar cJf "${SDK_DIR}".tar.xz "${SDK_DIR}"
+          du -skh "${SDK_DIR}".tar.xz
+          shasum -a 256 "${SDK_DIR}".tar.xz
+      - name: Upload Assembled SDK
+        if: ${{ matrix.os == 'ubuntu-22.04' && matrix.arch == 'x86_64' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SDK_DIR }}.tar.xz
+          path: ${{ env.SDK_DIR }}.tar.xz
+          compression-level: 0
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.*.swp
+.DS_Store

--- a/get-packages-and-swift-source.swift
+++ b/get-packages-and-swift-source.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 // The Termux packages to download and unpack
-var termuxPackages = ["libandroid-spawn", "libcurl", "libxml2"]
+// libxml2 needs liblzma and libiconv
+// libcurl needs zlib, libnghttp3, libnghttp2, libssh2, and openssl
+var termuxPackages = ["libandroid-spawn", "libcurl", "zlib", "libxml2", "libnghttp3", "libnghttp2", "libssh2", "openssl", "liblzma", "libiconv"]
 let termuxURL = "https://packages.termux.dev/apt/termux-main"
 
 let swiftRepos = ["llvm-project", "swift", "swift-experimental-string-processing", "swift-corelibs-libdispatch",
@@ -168,10 +170,10 @@ if !fmd.fileExists(atPath: termuxArchive.appendingPathComponent("Packages-\(ANDR
 let packages = try String(contentsOfFile: termuxArchive.appendingPathComponent("Packages-\(ANDROID_ARCH)"), encoding: .utf8)
 
 for termuxPackage in termuxPackages {
-  guard let packagePathRange = packages.range(of: "\\S+\(termuxPackage)_\\S+", options: .regularExpression) else {
+  guard let packagePathRange = packages.range(of: "Filename: \\S+/\(termuxPackage)_\\S+", options: .regularExpression) else {
     fatalError("couldn't find \(termuxPackage) in Packages list")
   }
-  let packagePath = packages[packagePathRange]
+  let packagePath = packages[packagePathRange].dropFirst("Filename: ".count).description
 
   guard let packageNameRange = packagePath.range(of: "\(termuxPackage)_\\S+", options: .regularExpression) else {
     fatalError("couldn't extract \(termuxPackage) .deb package from package path")
@@ -210,6 +212,9 @@ if !fmd.fileExists(atPath: sdkPath) {
   try fmd.removeItem(atPath: sdkPath.appendingPathComponent("usr/bin/curl-config"))
   try fmd.removeItem(atPath: sdkPath.appendingPathComponent("usr/bin/xml2-config"))
   try fmd.removeItem(atPath: sdkPath.appendingPathComponent("usr/share/man"))
+  try fmd.removeItem(atPath: sdkPath.appendingPathComponent("usr/lib/ossl-modules"))
+  try fmd.removeItem(atPath: sdkPath.appendingPathComponent("usr/lib/engines-3"))
+  try fmd.removeItem(atPath: sdkPath.appendingPathComponent("usr/etc"))
 }
 
 _ = runCommand("patchelf", with: ["--set-rpath", "$ORIGIN",


### PR DESCRIPTION
This PR adds a workflow job that runs at the end of the CI cycle. It takes the artifacts from the `build-sdk-and-tests` for each of the versions (release, devel, and trunk) and aggregates them into a single SDK archive. This is the start of addressing https://github.com/finagolfin/swift-android-sdk/issues/163, but does not yet generate a `toolchain.json` file or an `.artifactbundle`.

You can see the artifacts that it will generate at https://github.com/marcprux/swift-android-sdk/actions/runs/10781519718, which creates `swift-5.10.1-RELEASE-android-sdk.tar.xz`, `swift-6.0-DEVELOPMENT-SNAPSHOT-2024-07-19-a-android-sdk.tar.xz`, and `swift-DEVELOPMENT-SNAPSHOT-2024-07-15-a-android-sdk.tar.xz`. These archives can be used with a custom destination JSON file (not included, since it will need to reference the local NDK and host toolchain locations, which will vary from machine to machine).

In addition, this PR adds the following Termux packages to the SDK, which enables FoundationXML and FoundationNetworking: zlib, libnghttp3, libnghttp2, libssh2, openssl, liblzma, and libiconv. With these included, `XMLParser` and `URLSession` are working (albeit not HTTPS yet – we need to be able to hook into the Android certificate store somehow).