### PR TITLE
Add testing for swift-corelibs-foundation-android-test repo

### DIFF
--- a/.github/workflows/sdks.yml
+++ b/.github/workflows/sdks.yml
@@ -384,6 +384,15 @@ jobs:
           cd sa
           ~/sedinplace.sh "s%url: .*$%path: \"../swift-numerics\"),%" Package.swift
           ${TOOLCHAIN}/bin/swift build --build-tests --destination ${ARCH_JSON} -Xlinker -rpath -Xlinker \$ORIGIN/lib/swift/android
+      - name: Get swift-corelibs-foundation-android-test package
+        uses: actions/checkout@v4
+        with:
+          repository: marcprux/swift-corelibs-foundation-android-test
+          path: scfat
+      - name: Build swift-corelibs-foundation-android-test package
+        run: |
+          cd scfat
+          ${TOOLCHAIN}/bin/swift build --build-tests --destination ${ARCH_JSON} -Xlinker -rpath -Xlinker \$ORIGIN/lib/swift/android
       - name: Get cached Termux debug app for NIO tests
         if: ${{ matrix.arch == 'x86_64' }}
         id: cache-termux
@@ -451,6 +460,9 @@ jobs:
 
           cp sa/.build/$TARGET/debug/swift-algorithmsPackageTests.xctest pack
           echo 'adb shell /data/local/tmp/pack/swift-algorithmsPackageTests.xctest' >> ~/test-toolchain.sh
+
+          cp -ar scfat/.build/$TARGET/debug/swift-corelibs-foundationPackageTests.xctest scfat/.build/$TARGET/debug/swift-corelibs-foundation_TestFoundation.resources pack
+          echo 'adb shell /data/local/tmp/pack/swift-corelibs-foundationPackageTests.xctest' >> ~/test-toolchain.sh
 
           mkdir pack/crypto-vectors pack/swift-crypto_CryptoTests.resources
           cp swift-crypto/Tests/Test\ Vectors/* swift-crypto/Tests/_CryptoExtrasVectors/* pack/crypto-vectors

--- a/.github/workflows/sdks.yml
+++ b/.github/workflows/sdks.yml
@@ -461,7 +461,7 @@ jobs:
           cp sa/.build/$TARGET/debug/swift-algorithmsPackageTests.xctest pack
           echo 'adb shell /data/local/tmp/pack/swift-algorithmsPackageTests.xctest' >> ~/test-toolchain.sh
 
-          cp -ar scfat/.build/$TARGET/debug/swift-corelibs-foundationPackageTests.xctest scfat/.build/$TARGET/debug/swift-corelibs-foundation_TestFoundation.resources pack
+          cp -r scfat/.build/$TARGET/debug/swift-corelibs-foundationPackageTests.xctest scfat/.build/$TARGET/debug/swift-corelibs-foundation_TestFoundation.resources pack
           echo 'adb shell /data/local/tmp/pack/swift-corelibs-foundationPackageTests.xctest' >> ~/test-toolchain.sh
 
           mkdir pack/crypto-vectors pack/swift-crypto_CryptoTests.resources


### PR DESCRIPTION
This PR adds testing for the https://github.com/marcprux/swift-corelibs-foundation-android-test.git repository, which is a fork of https://github.com/apple/swift-corelibs-foundation.git that builds only the `Tests/` part of the package and adapts a number of Foundation tests to accommodate Android. A number of tests are disabled (mostly some daylight savings and Process forking tests), but most pass on the Android emulator.

Having this baseline of tests that pass for `swift-corelibs-foundation` will be useful to see what breaks (or is fixed) when `swift-foundation` is added to the mix.

Note that this PR relies on the additional Termux libraries added in https://github.com/finagolfin/swift-android-sdk/pull/167, since those are required to run the `XMLParser` and `URLSession` tests.