### PR TITLE
Add c-ares as Termux library dependency

### DIFF
--- a/.github/workflows/sdks.yml
+++ b/.github/workflows/sdks.yml
@@ -97,7 +97,7 @@ jobs:
             TAG="${{ needs.get-latest-toolchain.outputs.trunk-version }}"
           fi
           echo "tag=$TAG" >> $GITHUB_OUTPUT
-          KEY="$TAG-${{ matrix.arch }}-ndk-27b-bump-sdk"
+          KEY="$TAG-${{ matrix.arch }}-ndk-27b-c-ares-sdk"
           echo "key=$KEY" >> $GITHUB_OUTPUT
           if ${{ matrix.arch == 'x86_64' }}; then
             echo "aarch64-key=${KEY/x86_64/aarch64}" >> $GITHUB_OUTPUT

--- a/get-packages-and-swift-source.swift
+++ b/get-packages-and-swift-source.swift
@@ -2,8 +2,8 @@ import Foundation
 
 // The Termux packages to download and unpack
 // libxml2 needs liblzma and libiconv
-// libcurl needs zlib, libnghttp3, libnghttp2, libssh2, and openssl
-var termuxPackages = ["libandroid-spawn", "libcurl", "zlib", "libxml2", "libnghttp3", "libnghttp2", "libssh2", "openssl", "liblzma", "libiconv"]
+// libcurl needs zlib, libnghttp3, libnghttp2, libssh2, openssl, and c-ares
+var termuxPackages = ["libandroid-spawn", "libcurl", "zlib", "libxml2", "libnghttp3", "libnghttp2", "libssh2", "openssl", "liblzma", "libiconv", "c-ares"]
 let termuxURL = "https://packages.termux.dev/apt/termux-main"
 
 let swiftRepos = ["llvm-project", "swift", "swift-experimental-string-processing", "swift-corelibs-libdispatch",


### PR DESCRIPTION
Termux's libcurl was just changed to add a dependency on c-ares in libcurl 8.10.1-1 (https://github.com/termux/termux-packages/pull/21686), so we need to add that to the libraries downloaded and processed by `get-packages-and-swift-source.swift` in order for `FoundationNetworking` to work.