### PR TITLE
Remove c-ares since it is no longer a libcurl dependency

### DIFF
--- a/get-packages-and-swift-source.swift
+++ b/get-packages-and-swift-source.swift
@@ -2,8 +2,8 @@ import Foundation
 
 // The Termux packages to download and unpack
 // libxml2 needs liblzma and libiconv
-// libcurl needs zlib, libnghttp3, libnghttp2, libssh2, openssl, and c-ares
-var termuxPackages = ["libandroid-spawn", "libandroid-spawn-static", "libcurl", "zlib", "libxml2", "libnghttp3", "libnghttp2", "libssh2", "openssl", "liblzma", "libiconv", "c-ares"]
+// libcurl needs zlib, libnghttp3, libnghttp2, libssh2, and openssl
+var termuxPackages = ["libandroid-spawn", "libandroid-spawn-static", "libcurl", "zlib", "libxml2", "libnghttp3", "libnghttp2", "libssh2", "openssl", "liblzma", "libiconv"]
 let termuxURL = "https://packages.termux.dev/apt/termux-main"
 
 let swiftRepos = ["llvm-project", "swift", "swift-experimental-string-processing", "swift-corelibs-libdispatch",


### PR DESCRIPTION
c-ares support was removed as a dependency in https://github.com/termux/termux-packages/pull/21988